### PR TITLE
change output for explore not stdout

### DIFF
--- a/content/tutorials/additional-syntax.md
+++ b/content/tutorials/additional-syntax.md
@@ -21,7 +21,7 @@ new c2f, f2c in {
   }
   |
 
-  new result(`rho:io:result`) in {
+  new result in {
     // 0 C should be 32 F
     c2f!(0, *result)
     |
@@ -42,7 +42,7 @@ new greeter in {
     return!("Hello there, " ++ *name)
   }
   |
-  new result(`rho:io:result`) in {
+  new result in {
     greeter!("Joshy", *result)|
     greeter!("Tom", *result)
   }

--- a/content/tutorials/additional-syntax.md
+++ b/content/tutorials/additional-syntax.md
@@ -21,12 +21,12 @@ new c2f, f2c in {
   }
   |
 
-  new stdout(`rho:io:stdout`) in {
+  new result(`rho:io:result`) in {
     // 0 C should be 32 F
-    c2f!(0, *stdout)
+    c2f!(0, *result)
     |
     // 100 C should be 212 F
-    c2f!(100, *stdout)
+    c2f!(100, *result)
   }
 }
 ```
@@ -42,14 +42,14 @@ new greeter in {
     return!("Hello there, " ++ *name)
   }
   |
-  new stdout(`rho:io:stdout`) in {
-    greeter!("Joshy", *stdout)|
-    greeter!("Tom", *stdout)
+  new result(`rho:io:result`) in {
+    greeter!("Joshy", *result)|
+    greeter!("Tom", *result)
   }
 }
 ```
 
-What would the code `stdout!("I" ++ "<3" ++ "rholang")` output?
+What would the code `result!("I" ++ "<3" ++ "rholang")` output?
 - [ ] I <3 rholang
 - [ ] ["I", "<3", "rholang"]
 - [x] I<3rholang
@@ -82,7 +82,7 @@ What code could be parred with the previous code to leave the number `24` on `do
 ### Exercise
 Revisit the telephone game from lesson 3 and show that we could have used the `@message` pattern so `message` would be a process.
 
-What should replace the ... in `for(@x <- @y){stdout!(...)}` to make the program valid?
+What should replace the ... in `for(@x <- @y){result!(...)}` to make the program valid?
 - [ ] `@x`
 - [x] `x`
 - [ ] `*x`
@@ -103,12 +103,12 @@ else {
 The situations where you will use `if` are limitless and include guessing a secret word correctly, setting the high score in a video game, determining which poker hand is higher, and calculating the winner of an election. This example contract shows how you might check the status of a bank account.
 
 ```javascript
-new stdout(`rho:io:stdout`) in {
+new result in {
   for (@balance <= @"signTest") {
     if (balance > 0) {
-      stdout!("Account in good standing.")
+      result!("Account in good standing.")
     } else {
-      stdout!("Account overdrawn.")
+      result!("Account overdrawn.")
     }
   }
 }
@@ -148,17 +148,17 @@ Rholang also has the classic Boolean operators AND, OR, and NOT. The syntax is
 * `a or b` true when either `a` or `b` is true
 * `not a` true when `a` is false
 
-What would `stdout!(true and true)` output?
+What would `result!(true and true)` output?
 - [x] true
 - [ ] false
 - [ ] neither; that's invalid syntax
 
-What would `stdout!(not true)` output?
+What would `result!(not true)` output?
 - [ ] true
 - [x] false
 - [ ] neither; that's invalid syntax
 
-What would `stdout!((not not true) or false)` output?
+What would `result!((not not true) or false)` output?
 - [x] true
 - [ ] false
 - [ ] neither; that's invalid syntax

--- a/content/tutorials/bundles-interpolation.md
+++ b/content/tutorials/bundles-interpolation.md
@@ -7,10 +7,10 @@
 Alice is a rising celebrity who receives mail from her fans. They used to send mail directly to her.
 
 ```javascript
-new alice, stdout(`rho:io:stdout`) in {
+new result, alice in {
   // Alice reads fan mail
   for (mail <- alice) {
-    stdout!("Alice received a fanmail")
+    result!("Alice received a fanmail")
   }
   |
 
@@ -27,7 +27,7 @@ Write the code for a competitor to steal the mail  <!-- Answer in fanmailEve.rho
 The problem is that the competitors can listen on the same channel Alice can. So what she really needs is for her fans to have a "write-only bundle"
 
 ```javascript
-new alice, bob, eve, stdout(`rho:io:stdout`) in {
+new result, alice, bob, eve in {
   // Alice gets a lot of fan mail, so she
   // creates a new write only bundle and publishes it.
   new aliceFanMail in {
@@ -38,7 +38,7 @@ new alice, bob, eve, stdout(`rho:io:stdout`) in {
 
     // Alice also reads fan mail
     for (mail <= aliceFanMail) {
-      stdout!("Alice received a fanmail")
+      result!("Alice received a fanmail")
     }
   }
   |
@@ -54,7 +54,7 @@ new alice, bob, eve, stdout(`rho:io:stdout`) in {
   // because Alice's fanmail channel is write-only
   for (aliceFanMail <- alice) {
     for (@stolenMail <= aliceFanMail) {
-      stdout!(["Eve stole a message: ", stolenMail])
+      result!(["Eve stole a message: ", stolenMail])
     }
   }
 }
@@ -75,7 +75,7 @@ Complete Alice's code so that she can get Bob the address he needs.
 
 Here's the answer:
 ```javascript
-new alice, bob, eve, stdout(`rho:io:stdout`) in {
+new result, alice, bob, eve in {
 
   // Alice get a lot of fan mail, so she
   // creates a new write only bundle and publishes it.
@@ -89,7 +89,7 @@ new alice, bob, eve, stdout(`rho:io:stdout`) in {
 
     // Alice also reads fan mail
     for (mail <- aliceFanMail) {
-      stdout!("Alice received a fanmail")
+      result!("Alice received a fanmail")
     }
   }
   |
@@ -110,7 +110,7 @@ new alice, bob, eve, stdout(`rho:io:stdout`) in {
     alice!(*return) |
     for (aliceFanMail <- return) {
       for (@stolenMail <= aliceFanMail) {
-        stdout!(["Eve stole a message: ", stolenMail])
+        result!(["Eve stole a message: ", stolenMail])
       }
     }
   }
@@ -132,7 +132,7 @@ I used to play a game called jackpot as a kid. One player would throw the ball a
 Playing jackpot is just the opposite of sending fanmail. Before there were many fans all sending to one celebrity. Now there is one thrower, sending to one of many recipients
 
 ```javascript
-new throw, stdout(`rho:io:stdout`) in {
+new result, throw in {
   // Throw the ball worth five points
   throw!(5)
   |
@@ -144,11 +144,11 @@ new throw, stdout(`rho:io:stdout`) in {
 
   // Bill and Paige both try to catch
   for (points <= throw){
-    stdout!("Bill caught it")
+    result!("Bill caught it")
   }
   |
   for (points <= throw){
-    stdout!("Paige caught it")
+    result!("Paige caught it")
   }
 }
 ```
@@ -161,7 +161,7 @@ Who will catch the ball in the jackpot code?
 
 
 ### Exercise
-Exercise: Use stdoutAck to display how many points each person actually gets when they catch the ball.
+Exercise: Use resultAck to display how many points each person actually gets when they catch the ball.
 <!-- solution in jackpotNicePrinting.rho -->
 
 
@@ -174,19 +174,19 @@ How is this game in rholang different than the real game where one ball is throw
 
 
 ## Side Bar: String Operations
-Most programming languages will allow you to join or "concatenate" two strings together, and rholang is no exception. We can `stdout!("Hello " ++ "world")`, but we can't concatenate a string with an int.
+Most programming languages will allow you to join or "concatenate" two strings together, and rholang is no exception. We can `result!("Hello " ++ "world")`, but we can't concatenate a string with an int.
 
-One solution is to use `stdoutAck` andsend acknowledgements. Another option is to print a list  `stdout!(["Bill caught it. Points earned: ", *points])`. We'll go into more detail about both techniques in future lessons.
+One solution is to use `resultAck` andsend acknowledgements. Another option is to print a list  `result!(["Bill caught it. Points earned: ", *points])`. We'll go into more detail about both techniques in future lessons.
 
 A final option is to use string interpolation. String interpolation allows you to put placeholders into your strings and replace them with actual values using a map.
 
 ```javascript
-new stdout(`rho:io:stdout`) in {
+new result in {
 
   printStuff!({"noun": person, "adverb": sideways}) |
   
   contract printStuff(map) = {
-    stdout!("The ${noun} jumped ${adverb}" %% *map)
+    result!("The ${noun} jumped ${adverb}" %% *map)
   }
 }
 ```
@@ -206,7 +206,7 @@ What code would Eve have to par in to throw an imposter ball worth 100 points?
 We solve this problem by making sure that the public can only read from the throw channel, but not write to it.
 
 ```javascript
-new gameCh, stdout(`rho:io:stdout`) in {
+new result, gameCh in {
   new throw in {
 
     //Give out read-only access
@@ -221,7 +221,7 @@ new gameCh, stdout(`rho:io:stdout`) in {
   // Bill and Paige join the game
   for (throw <- gameCh){
     for (points <= throw){
-      stdout!(["Bill caught it. Points: ", *points])
+      result!(["Bill caught it. Points: ", *points])
     }
   }
   |

--- a/content/tutorials/data-structures.md
+++ b/content/tutorials/data-structures.md
@@ -41,11 +41,14 @@ Pro tip: It is also possible to slice a byte array. Experiment with that on your
 
 ## Tuples
 
-Tuple can rhyme with either "couple" or "drupal"; both pronunciations are correct. You've seen tuples before when you wrote contracts that take in multiple arguments like `contract c(x, y, z) = { Nil }`. The number of items in a tuple is know as its arity. So the tuple received by contract `c` is arity three.
+Tuple can rhyme with either "couple" or "drupal"; both pronunciations are correct. 
+You've seen tuples before when you wrote contracts that take in multiple arguments like `contract c(x, y, z) = { Nil }`. The number of items in a tuple is know as its arity. So the tuple received by contract `c` is arity three.
 
-Tuples contain several pieces of data **in order**. They are always a fixed arity, and have relatively few methods. Thus they are the least interesting data structure, but at the same time, the most fundamental. Let's look at some of the methods offered by tuples.
+Tuples contain several pieces of data **in order**. They are always a fixed arity, and have relatively few methods. Thus they are the least interesting data structure, but at the same time, the most fundamental. A tuple of arity three would be `(x, y, z)`
 
-```javascript
+<!-- Let's look at some of the methods offered by tuples. -->
+
+<!-- ```javascript
 new print, tCh in {
 
   tCh!!((3, 4, 5))|
@@ -79,7 +82,7 @@ What would `("a", "b", "c").nth(3)` evaluate to?
 
 ### Exercise
 
-Write a program that takes in a 4-tuple and prints elements 0 and 3 to the screen.
+Write a program that takes in a 4-tuple and prints elements 0 and 3 to the screen. -->
 
 ## Lists
 

--- a/content/tutorials/data-structures.md
+++ b/content/tutorials/data-structures.md
@@ -9,11 +9,11 @@ Let's start with a familiar idea. We've seen strings since the very first progra
 String's length method tells how many characters are in a string. While it's slice method creates a new string with some characters sliced off of each end. Strings also support the `++` operator for concatenation.
 
 ```javascript
-new wordLength, stdout(`rho:io:stdout`) in {
+new result, wordLength in {
   contract wordLength(@word) = {
-    stdout!("How many characters in " ++ word)|
-    stdout!(word.length())|
-    stdout!("Shorter version: " ++ word.slice(0, 5))
+    result!("How many characters in " ++ word)|
+    result!(word.length())|
+    result!("Shorter version: " ++ word.slice(0, 5))
   }
   |
   wordLength!("Cantaloupe")
@@ -46,7 +46,7 @@ Tuple can rhyme with either "couple" or "drupal"; both pronunciations are correc
 Tuples contain several pieces of data **in order**. They are always a fixed arity, and have relatively few methods. Thus they are the least interesting data structure, but at the same time, the most fundamental. Let's look at some of the methods offered by tuples.
 
 ```javascript
-new tCh, print(`rho:io:stdout`) in {
+new print, tCh in {
 
   tCh!!((3, 4, 5))|
 
@@ -86,32 +86,32 @@ Write a program that takes in a 4-tuple and prints elements 0 and 3 to the scree
 Lists are a lot like tuples, but they are made with square brackets instead of parentheses. They also have more methods, and can be concatenated or glued together using the `++` operator just like strings can. Here are examples of all of list's methods.
 
 ```javascript
-new lCh, stdout(`rho:io:stdout`) in {
+new result, lCh in {
 
   // Make a new list, l
   lCh!!([3, 4, 5])|
 
   // Test nth
   for (@l <- lCh){
-    stdout!("Test nth. Expected: 5. Got: ${ans}" %% {"ans": l.nth(2)})
+    result!("Test nth. Expected: 5. Got: ${ans}" %% {"ans": l.nth(2)})
   }
   |
 
   // Test toByteArray
   for (@l <- lCh){
-    stdout!(["Test toByteArray. Got: ", l.toByteArray()])
+    result!(["Test toByteArray. Got: ", l.toByteArray()])
   }
   |
 
   // Test slice
   for (@l <- lCh){
-    stdout!(["Test slice. Expected: [4, 5]. Got: ", l.slice(1, 3)])
+    result!(["Test slice. Expected: [4, 5]. Got: ", l.slice(1, 3)])
   }
   |
 
   // Test length
   for (@l <- lCh){
-    stdout!("Test length. Expected: 3. Got: '${ans}" %% {"ans": l.length()})
+    result!("Test length. Expected: 3. Got: '${ans}" %% {"ans": l.length()})
   }
 }
 ```
@@ -137,50 +137,50 @@ new logRun, runsCh in {
 Sets are similar to lists in some ways, but the one big difference is that sets **are not ordered**. A set is a collection of processes, but there is no first or last item in the set. There are also **no duplicates** allowed in sets. Let's take a look at some of set's methods.
 
 ```javascript
-new sCh, stdout(`rho:io:stdout`) in {
+new result, sCh in {
 
   sCh!!(Set(3, 4, 5))|
 
   // Test toByteArray
   for (@s <- sCh){
-    stdout!(["Test toByteArray. Got: ", s.toByteArray()])
+    result!(["Test toByteArray. Got: ", s.toByteArray()])
   }
   |
 
   // Test Add
   for (@s <- sCh){
-    stdout!(["Test add. Expected Set(3, 4, 5, 6), Got: ", s.add(6)])
+    result!(["Test add. Expected Set(3, 4, 5, 6), Got: ", s.add(6)])
   }
   |
 
   // Test Diff
   for (@s <- sCh){
-    stdout!(["Test diff. Expected: Set(5) Got: ", s.diff(Set(3, 4))])
+    result!(["Test diff. Expected: Set(5) Got: ", s.diff(Set(3, 4))])
   }
   |
 
   // Test Union
   for (@s <- sCh){
-    stdout!(["Test union. Expected: Set(1, 2, 3, 4, 5). Got: ", s.union(Set(1, 2))])
+    result!(["Test union. Expected: Set(1, 2, 3, 4, 5). Got: ", s.union(Set(1, 2))])
   }
   |
 
   // Test Delete
   for (@s <- sCh){
-    stdout!(["Test delete. Expected: Set(3, 4). Got: ", s.delete(5)])
+    result!(["Test delete. Expected: Set(3, 4). Got: ", s.delete(5)])
   }
   |
 
   // Test Contains
   for (@s <- sCh){
-    stdout!(["Test contains. Expected: true. Got:", s.contains(5)])|
-    stdout!(["Test contains. Expected: false. Got: ", s.contains(6)])
+    result!(["Test contains. Expected: true. Got:", s.contains(5)])|
+    result!(["Test contains. Expected: false. Got: ", s.contains(6)])
   }
   |
 
   // Test Size
   for (@s <- sCh){
-    stdout!("Test size. Expected 3. Got: ${ans}" %% {"ans": s.size()})
+    result!("Test size. Expected 3. Got: ${ans}" %% {"ans": s.size()})
   }
 }
 ```
@@ -204,7 +204,7 @@ What is the result of `Set(1,2,3) == Set(3,2,1)`
 Maps are a lot like sets but they contain **key value pairs**. Maps are also unordered, but when you add an item (which is now known as a key) you also add an associated value. Here are examples of all of map's methods.
 
 ```javascript
-new mCh, print(`rho:io:stdout`) in {
+new print, mCh in {
 
   mCh!!({"a": 3, "b": 4, "c": 5})|
 
@@ -281,7 +281,7 @@ What is the result of `{"years": 1, "weeks": 52, "days": 365}.get(52)`
 To demonstrate the usefulness of maps in rholang, let's consider this contract that looks up the capital of any country (that I bothered to type).
 
 ```javascript
-new capitalOf, print(`rho:io:stdout`) in {
+new print, capitalOf in {
   new mapCh in {
 
     // Use a persistent send instead of peeking later
@@ -448,13 +448,13 @@ We've learned about several interesting data structures in this lesson. Data str
 In this example, Alice and Bob each have one unforgeable name (that I've called key). The keys may be useful on their own (for things not shown in the snippet), but only when used together, can the contract shown be called. This is known as "rights amplification".
 
 ```javascript
-new alice, bob, key1, key2, stdout(`rho:io:stdout`) in {
+new alice, result, bob, key1, key2 in {
 
   alice!(*key1)|
   bob!(*key2)|
 
   contract @(*key1, *key2)(_) = {
-    stdout!("Congratulations, Alice and Bob, you've cooperated.")
+    result!("Congratulations, Alice and Bob, you've cooperated.")
   }
 }
 ```

--- a/content/tutorials/join.md
+++ b/content/tutorials/join.md
@@ -12,7 +12,7 @@ Rholang has the join operator for exactly this situation. To perform a join, jus
 
 ```javascript
 for (p1Pushups <- player1; p2Pushups <- player2) {
-  stdout!("The winner is...")
+  result!("The winner is...")
 }
 ```
 
@@ -35,12 +35,12 @@ One may have been tempted to solve the rocket problem by first receiving one lau
 >This is the BAD way to solve the problem.
 
 ```javascript
-new aliceLaunch, bobLaunch, stdout(`rho:io:stdout`) in {
+new result, aliceLaunch, bobLaunch in {
 
   // Listen for Alice's then Bob's launch commands
   for (x <- aliceLaunch){
     for (y <- bobLaunch){
-      stdout!("Launching the rocket")
+      result!("Launching the rocket")
     }
   }
   |
@@ -61,10 +61,10 @@ When using a join, she can still change her mind because the `for` won't consume
 ## Launch Solution
 
 ```javascript
-new aliceLaunch, bobLaunch, stdout(`rho:io:stdout`) in {
+new result, aliceLaunch, bobLaunch in {
   // Listen for both launch commands
   for (x <- aliceLaunch; y <- bobLaunch){
-    stdout!("Launching the rocket")
+    result!("Launching the rocket")
   }
   |
   // When ready, Engineers send their commands
@@ -109,7 +109,7 @@ There is a game where two players will each send a message on separate channels.
 In this case we actually don't want to use join because we care which player went first. Hope I didn't trick you ;)
 
 ```javascript
-new p1, p2, stdout(`rho:io:stdout`) in {
+new result, p1, p2 in {
   // Send messages like in both orders
   p1!("Send any message") |
   p2!("Hope I win") |
@@ -117,7 +117,7 @@ new p1, p2, stdout(`rho:io:stdout`) in {
   // When Player one wins
   for (m2 <- p2){
     for (m1 <- p1){
-      stdout!("Player one wins!")
+      result!("Player one wins!")
     }
   }
   |
@@ -125,7 +125,7 @@ new p1, p2, stdout(`rho:io:stdout`) in {
   // When player two wins
   for (m1 <- p1){
     for (m2 <- p2){
-      stdout!("Player two wins!")
+      result!("Player two wins!")
     }
   }
 }

--- a/content/tutorials/names-and-processes.md
+++ b/content/tutorials/names-and-processes.md
@@ -10,7 +10,7 @@ Now let's make them do something more interesting by passing the message along l
 
 
 ```javascript
-new alice, bob, stdout(`rho:io:stdout`) in {
+new result, alice, bob in {
   // Start the game by sending a message to Alice
   alice!("How to program: Change stuff and see what happens.")
   |
@@ -26,7 +26,7 @@ new alice, bob, stdout(`rho:io:stdout`) in {
   // Concurrently, Bob will listens for the message
   for (message <- bob) {
     // Bob is the last player, so he'll announce the message
-    stdout!(*message)
+    result!(*message)
   }
 }
 ```
@@ -35,7 +35,7 @@ As the message says, you learn most when you experiment. So be sure to change th
 
 ### Exercise
 
-That telephone game was fun, but it's always better the have more players. Go ahead and add a third player called Charlie. Instead of printing to `stdout`, bob will send the message along to Charlie. Then Charlie will print it to the screen. The More the Merrier!
+That telephone game was fun, but it's always better the have more players. Go ahead and add a third player called Charlie. Instead of printing to `result`, bob will send the message along to Charlie. Then Charlie will print it to the screen. The More the Merrier!
 
 
 
@@ -57,7 +57,7 @@ Did you notice the `*` in `bob!(*message)`? In rholang there are two kinds of th
 
 A "process" is any piece of rholang code such as our telephone game, or our pizza shop order program. Processes can be big hundred-line programs or small on-liners. They can even be tiny pieces of code that are just values.  Here are some example processes.
 
- - `stdout!("Sup Rholang?")` A common send
+ - `result!("Sup Rholang?")` A common send
  - `Nil` The smallest possible process. It literally means "do nothing".
  - `for(msg <- phone){Nil}` A common receive that does nothing when a message arrives.
  - `"Hello World"` Another small process that also does nothing. These are called "Ground Terms".
@@ -137,7 +137,7 @@ What is `@@Nil`?
 - [ ] `@"BobsPhone"`
 - [ ] `*"BobsPhone"`
 - [ ] `@*"BobsPhone"`
-- [ ] `stdout!("BobsPhone")`
+- [ ] `result!("BobsPhone")`
 
 
 
@@ -148,4 +148,4 @@ What is `@@Nil`?
 
 Instead of a linear telephone game where each player passes the message to the next, let's add a branch in the game. So now Bob will send to Charlie like before, but Bob will also send to Dawn.
 
-Each branch can be as long as you want, but at the end of each branch, print the message to `stdout`.
+Each branch can be as long as you want, but at the end of each branch, print the message to `result`.

--- a/content/tutorials/object-capabilities.md
+++ b/content/tutorials/object-capabilities.md
@@ -10,7 +10,7 @@ In this lesson we'll build up a few example projects that uses state channels, a
 Let's revisit the air traffic control example from lesson 4. Previously controllers were able to broadcast weather and runway information by using a repeated send. But they were not able to update the information. And we all know weather can change unpredictably. So in this example we'll store the current information on a state channel, and give the controllers a capability to update it as necessary.
 
 ```javascript
-new stationFactory, stdout(`rho:io:stdout`) in {
+new result, stationFactory in {
   contract stationFactory(initialMessage, getInfo, setInfo) = {
     new currentMessage in {
       // Populate the initial message
@@ -44,7 +44,7 @@ new stationFactory, stdout(`rho:io:stdout`) in {
   }
   |
   // Listener tunes in to receive latest message
-  airportInfo!(*stdout)
+  airportInfo!(*result)
 }
 ```
 

--- a/content/tutorials/off-chain.md
+++ b/content/tutorials/off-chain.md
@@ -8,10 +8,9 @@ So far all of our exercises have existed entirely inside the world of rholang. W
 The name registry provides a partial solution to the problem. To register a name follow this example.
 
 ```javascript
-new doubler,
+new result, doubler,
   uriChan,
-  insertArbitrary(`rho:registry:insertArbitrary`),
-  stdout(`rho:io:stdout`) in {
+  insertArbitrary(`rho:registry:insertArbitrary`) in {
 
    // This is a silly contract that we'll register
   contract doubler(@n /\ Int, return) = {
@@ -24,7 +23,7 @@ new doubler,
  
   // Wait for URI response
   for(@uri <- uriChan) {
-    stdout!(uri)
+    result!(uri)
   }
 }
 ```
@@ -33,9 +32,8 @@ new doubler,
 To look a name up to use it later, try this
 
 ```javascript
-new doublerCh,
-  lookup(`rho:registry:lookup`),
-  stdout(`rho:io:stdout`) in {
+new result, doublerCh,
+  lookup(`rho:registry:lookup`) in {
   
   // Ask the registry to lookup the URI and send the contract back on doublerCh
   lookup!(`rho:id:fos1m8yaki3s8g1ytzkr6boucnhab6nafoco8ww63xqj5k8aa1xfza`, *doublerCh) |
@@ -43,8 +41,8 @@ new doublerCh,
   // Wait to receive the answer back from the registry
   for( doubler <- doublerCh) {
     
-    // Double a number and send the answer to stdout
-    doubler!(7, *stdout)
+    // Double a number and send the answer to result
+    doubler!(7, *result)
   }
 }
 ```

--- a/content/tutorials/pattern-matching.md
+++ b/content/tutorials/pattern-matching.md
@@ -98,7 +98,7 @@ new greeter in {
     return!("Hello there, world")
   }
   |
-  new result(`rho:io:result`) in {
+  new result in {
     greeter!("Joshy", *result)|
     greeter!("Tom", *result)
   }

--- a/content/tutorials/pattern-matching.md
+++ b/content/tutorials/pattern-matching.md
@@ -8,15 +8,15 @@ Similarly, we can match sentence patterns. The sentences "I like cheese" and "I 
 The most obvious place that rholang uses pattern matching is in its `match` construct which works as shown here.
 
 ```javascript
-new patternMatcher, stdout(`rho:io:stdout`) in {
+new result, patternMatcher in {
 
   for (x <= patternMatcher) {
    match *x {
-    Nil       => stdout!("Got the stopped process")
-    "hello"   => stdout!("Got the string hello")
-    [x, y]    => stdout!("Got a two-element list")
-    Int       => stdout!("Got an integer")
-    _         => stdout!("Got something else")
+    Nil       => result!("Got the stopped process")
+    "hello"   => result!("Got the string hello")
+    [x, y]    => result!("Got a two-element list")
+    Int       => result!("Got an integer")
+    _         => result!("Got something else")
    }
   }
   |
@@ -98,9 +98,9 @@ new greeter in {
     return!("Hello there, world")
   }
   |
-  new stdout(`rho:io:stdout`) in {
-    greeter!("Joshy", *stdout)|
-    greeter!("Tom", *stdout)
+  new result(`rho:io:result`) in {
+    greeter!("Joshy", *result)|
+    greeter!("Tom", *result)
   }
 }
 ```
@@ -114,14 +114,14 @@ Write a series of contracts that calculate the area of a rectangle. In the most 
 You can do cool things with pattern matching like `for(@{x!(P)} <- y){ Q }` which will only reduce if the process sent on channel `x` matches the pattern of a single send. Then in the process Q you will have bound the variables `x`, the channel, and `P`, the process being sent
 
 ```javascript
-new patternMatcher, stdout(`rho:io:stdout`) in {
+new result, patternMatcher in {
 
   for (x <= patternMatcher) {
    match *x {
-    Nil               => stdout!("Got the stopped process")
-    {_!(_)}           => stdout!("Got a send")
-    {for(@0 <- _){_}} => stdout!("Got a receive on @0")
-    _                 => stdout!("Got something else")
+    Nil               => result!("Got the stopped process")
+    {_!(_)}           => result!("Got a send")
+    {for(@0 <- _){_}} => result!("Got a receive on @0")
+    _                 => result!("Got something else")
    }
   }
   |
@@ -150,7 +150,7 @@ There may be times when you want to match either of two patterns, or you want to
 To match any one of several patterns you use the "union" operator, `\/`
 
 ```javascript
-new log(`rho:io:stdout`), binderChecker in {
+new log, binderChecker in {
   contract binderChecker(@data, return) = {
     match data {
       "nombre" \/ "name" => return!("name-like")
@@ -167,7 +167,7 @@ new log(`rho:io:stdout`), binderChecker in {
 To match both of two patterns you use the "intersection" operator, `/\`. In this example we are verifying that registration data is valid. A registrant must supply their name and age, and may supply any amount of additional data. By the way, this technique for storing key-value data is often known as "RHOCore".
 
 ```javascript
-new print(`rho:io:stdout`), register in {
+new print, register in {
 
   for (@{{@"name"!(_) | _} /\ {@"age"!(_) | _}} <= register){
     print!("Both name and age were in the data")
@@ -184,7 +184,7 @@ new print(`rho:io:stdout`), register in {
 }
 ```
 
-Notice I called my stdout channel `print` that time. You can call those names anything you'd like. Although it's generally good to be consistent so as not to confuse anyone. From here on I'll stick with `stdout`.
+Notice I called my result channel `print` that time. You can call those names anything you'd like. Although it's generally good to be consistent so as not to confuse anyone. From here on I'll stick with `result`.
 
 ### Exercise
 The union example here is pretty basic. Expand it so it can match more languages and more words. Also write tests that show what happens when only the default pattern is matched.
@@ -197,7 +197,7 @@ Several lessons ago we discussed how bundles can be used to make read- or write-
 In this example code an army has a missile and they maintain control of launching the missile by building the capability on an unforgeable name. Because of diplomatic relationships, the army will allow the public to inspect the missile for safety, but certainly not launch it.
 
 ```javascript
-new log(`rho:io:stdout`), missile in {
+new log, missile in {
   contract @(*missile, "launch")(_) = {
     log!("launching...")
   }
@@ -229,7 +229,7 @@ new getInspectionChannel, ack in {
 In order to solve the problem the army simply gives out a bundled version of the compound name so that it cannot be taken apart by pattern matching.
 
 ```javascript
-new getInspectionChannel, log(`rho:io:stdout`), missile in {
+new log, getInspectionChannel, missile in {
   contract @(*missile, "launch")(_) = {
     log!("launching...")
   }

--- a/content/tutorials/receiving.md
+++ b/content/tutorials/receiving.md
@@ -22,13 +22,13 @@ BTW, lines that start with `//` are called comments. They're just there for huma
 
 ![Pizza shop can receive messages on its channel.](./images/receiving-pizza.png)
 
-The following code sends a message on a channel for a pizza shop and the pizza shop receives it. The pizza shop acknowledges receiving the message by printing to `stdout`.
+The following code sends a message on a channel for a pizza shop and the pizza shop receives it. The pizza shop acknowledges receiving the message by printing to `result`.
 
-new pizzaShop, stdout(`rho:io:stdout`) in {
+new result, pizzaShop in {
   pizzaShop!("2 medium pies")
   |
   for(order <- pizzaShop){
-    stdout!("Order Received.")
+    result!("Order Received.")
   }
 }
 
@@ -60,9 +60,9 @@ Our pizza shop example illustrates comm events nicely, but it isn't very realist
 Luckily it's possible to deploy code once, and have it run _every_ time it receives a message. This kind of thing is called a "smart contract". Let's look at some code for a coffee shop that is much superior to the pizza shop.
 
 ```javascript
-new coffeeShop, stdout(`rho:io:stdout`) in {
+new result, coffeeShop in {
   contract coffeeShop(order) = {
-    stdout!("Coffee Order Received")
+    result!("Coffee Order Received")
   }
   |
   coffeeShop!("one hot chocolate")
@@ -104,9 +104,9 @@ Notice this is different from a normal `for` because it has a double arrow `<=` 
 The pizza shop could use a contract like the one the coffee shop had. Let's write it one but use a persistent for instead of a contract. Try to write the entire thing from scratch so you remember the syntax better.
 
 ```javascript
-new pizzaShop, stdout(`rho:io:stdout`) in {
+new result, pizzaShop in {
   for (order <= pizzaShop) {
-    stdout!("Pizza Order Received")
+    result!("Pizza Order Received")
   }
   |
   pizzaShop!("one hot chocolate")

--- a/content/tutorials/send-and-peek.md
+++ b/content/tutorials/send-and-peek.md
@@ -15,13 +15,13 @@ An air traffic control tower may be interested in doing just the opposite -- sen
 The control tower just needs a minor adjustment in their code to make the send persistent. Rather than sending with a single `!`, they will use a double `!!`.
 
 ```javascript
-new airportInfo, stdout(`rho:io:stdout`) in {
+new result, airportInfo in {
   // ATC sends the info
   airportInfo!!("No wind; Runway 11")
   |
   // Pilot receives the info
   for (info <- airportInfo) {
-    stdout!(*info)
+    result!(*info)
   }
 }
 ```
@@ -31,7 +31,7 @@ Confirm for yourself that the original send is still in the tuplespace.
 ### Exercise
 Modify the above code so that a second pilot also receives the information. Still, the send persists.
 
-By the way, did you notice that we don't need `new stdout(...) in {}` when we don't actually print anything to the screen `stdout`?
+By the way, did you notice that we don't need `new result in {}` when we don't actually print anything to the screen `result`?
 
 How many comm events happen in `for (x <- y) {Nil} | y!!(Nil)`
 - [x] `1`
@@ -46,14 +46,14 @@ Persistent sends and receives are very useful as we just showed. But often norma
 A better solution is to use a normal send and require each pilot who receives the message to put it back on the channel when they are done.
 
 ```javascript
-new airportInfo, stdout(`rho:io:stdout`) in {
+new result, airportInfo in {
   // ATC sends the info
   airportInfo!("No wind; Runway 11")
   |
 
   // Pilot receives the info
   for (info <- airportInfo) {
-    stdout!(*info)
+    result!(*info)
     // TODO Pilot MUST put the info back
   }
   |
@@ -86,14 +86,14 @@ One problem with the code above is that a forgetful pilot may not actually put t
 To "peek" at what's on a channel without consuming it, use the `<<-` operator.
 
 ```javascript
-new airportInfo, stdout(`rho:io:stdout`) in {
+new result, airportInfo in {
   // ATC sends the info
   airportInfo!("No wind; Runway 11")
   |
 
   // Pilot receives the info
   for (info <<- airportInfo) {
-    stdout!(*info)
+    result!(*info)
   }
   |
 

--- a/content/tutorials/sending.md
+++ b/content/tutorials/sending.md
@@ -6,15 +6,15 @@ There is a long-standing tradition in programming that your first program should
 !["Person waiving hello"](./images/sending-helloWorld.png)
 
 ```javascript
-new stdout(`rho:io:stdout`) in {
-  stdout!("Hello World!")
+new result in {
+  result!("Hello World!")
 }
 ```
 
 ### Exercise
 Make the program print "Rholang rocks!" instead of "Hello World".
 
-## WTH is stdout?
+## WTH is result?
 
 ![Channels are like mailboxes for sending messages](./images/sending-mailbox.png)
 
@@ -22,17 +22,17 @@ The heart of rholang is communicating on channels. Channels are communication li
 
 ![Redo this diagram!](./images/sending-sendSyntax.png)
 
-We created the channel `stdout` on the first line of the program with `new stdout`. You'll create lots of channels as you learn rholang. We also gave our channel a special power by including `(rho:io:stdout)`. More on that later, but for now just know that you need that part in parentheses to make text actually appear on the screen.
+We created the channel `result` on the first line of the program with `new result`. You'll create lots of channels as you learn rholang. More on that later, but for now just know that you need that part in parentheses to make text actually appear on the screen.
 
 
 ## Using other channels
 
 ![Sent messages wait to be received here in "message purgatory"... JK, it's called the "tuplespace"](./images/sending-mailboxes.png)
 
-You can actually send messages on lots of channels, not just `stdout`. But unlike `stdout` they won't display on the screen because we won't add any special powers to them.
+You can actually send messages on lots of channels, not just `result`. The result will be the first name introduces when we `explore` read only. For deploys on rchain we use a special name for resuls anyname(`rho:rchain:deployId) to get the result of a deploy. More on that later.
 
 ```javascript
-new randoChannel in {
+new result, randoChannel in {
   randoChannel!("This won't be on the screen")
 }
 ```
@@ -54,8 +54,8 @@ Storage Contents:
 In rholang we don't tell the computer to do one thing, then another, then a third. Rather we tell it all the things to do, and it does them "concurrently," or all at once.
 
 ```javascript
-new chan1, stdout(`rho:io:stdout`) in {
-  stdout!("I'm on the screen")
+new result, chan1 in {
+  result!("I'm on the screen")
   |
   chan1!("I'm in the tuplespace")
 }
@@ -78,9 +78,9 @@ Print two messages, "Rick" and "Morty", on the screen in one program.
 
 ## Quiz
 
-What will `stdout!("Programming!")` print to the screen?
+What will `result!("Programming!")` print to the screen?
 - [x] Programming!
-- [ ] stdout!
+- [ ] result!
 - [ ] Nothing
 
 
@@ -88,15 +88,15 @@ What channel does `what!("Up")` send a message on?
 - [ ] `Up`
 - [x] `what`
 - [ ] `what`
-- [ ] `stdout`
+- [ ] `result`
 
 
 Which does rholang do first in
 
 ```javascript
-stdout!("Dogs")
+result!("Dogs")
 |
-stdout!("Cats")
+result!("Cats")
 ```
 - [ ] prints "Dogs"
 - [ ] prints "Cats"

--- a/content/tutorials/state-channels.md
+++ b/content/tutorials/state-channels.md
@@ -11,7 +11,7 @@ By now you're good at sending data to the tuplespace, and receiving data from th
 Another way in which rholang is unique is that it doesn't have traditional variables. Instead, we can just use the tuplespace to store our data. Whenever you want to set something aside for later, just send it on some channel and receive it back later. Channels that are used in this way are called "state channels", and often have `Ch` at the end of their name
 
 ```javascript
-new stdout(`rho:io:stdout`), boxCh in {
+new result, boxCh in {
   // To save data we just put it in the box
   boxCh!(42)
   |
@@ -19,7 +19,7 @@ new stdout(`rho:io:stdout`), boxCh in {
   // Then to get data back out
   for (data <- boxCh) {
     // Do whatever you want with the data here.
-    stdout!(*data)
+    result!(*data)
   }
 }
 ```
@@ -78,7 +78,7 @@ A few lessons back we discussed the patience game, where each player hopes to be
 Take a minute to remind yourself of the problem we had. With a state channel, we can solve this problem properly.
 
 ```javascript
-new P1, P2, stdout(`rho:io:stdout`) in {
+new result, P1, P2 in {
 
   // active gets its own scope so players can't change its value.
   new active in {
@@ -86,13 +86,13 @@ new P1, P2, stdout(`rho:io:stdout`) in {
     |
     for(_ <- active; _ <- P1) {
       for( _ <- P2) {
-        stdout!("P2 Wins")
+        result!("P2 Wins")
       }
     }
     |
     for(_ <- active; _ <- P2) {
       for (_ <- P1) {
-        stdout!("P1 Wins")
+        result!("P1 Wins")
       }
     }
   }
@@ -118,7 +118,7 @@ In this example, we'll create an object that represents a basic click counter. T
 * Methods: increase, reset
 
 ```javascript
-new currentCount, increase, reset, check, stdout(`rho:io:stdout`) in {
+new result, currentCount, increase, reset, check in {
   
   // Starting the counter at 0
   currentCount!(0) |
@@ -152,7 +152,7 @@ new currentCount, increase, reset, check, stdout(`rho:io:stdout`) in {
 
           // And check it's value afterwards
           for(_ <- ack; count <- currentCount) {
-            stdout!(*count)
+            result!(*count)
           }
         } 
       }
@@ -178,7 +178,7 @@ If you've programmed in other languages like java you may be familiar with const
 The counter is a useful construct in rholang, and you'll likely find that you use it in your projects. The problem is that many projects may want to use counters, and having just one is insufficient. So the solution is to make a factory contract that makes counters. When the factory contract is called, it sends back a brand new counter.
 
 ```javascript
-new counterFactory, stdout(`rho:io:stdout`) in {
+new result, counterFactory in {
   contract counterFactory(increase, reset) = {
     new currentCount in {
       // Start the counter at zero

--- a/content/tutorials/unforgable-names.md
+++ b/content/tutorials/unforgable-names.md
@@ -10,7 +10,7 @@ Getting back to rholang, `order` is initially a free variable, but it gets bound
 
 ```javascript
 for (order <= coffeeShop) {
-  stdout!("Coffee Order Received")
+  result!("Coffee Order Received")
 }
 ```
 
@@ -18,7 +18,7 @@ The same is true when we use `contract`s.
 
 ```javascript
 contract coffeeShop(order) = {
-  stdout!("Coffee Order Received")
+  result!("Coffee Order Received")
 }
 ```
 
@@ -59,11 +59,11 @@ State whether `x` is bound or free in each of the following code snippets.
 `for` and `contract` are perfect for binding variables inside of continuations. It turns out that the `new` operator also binds variables. What does it bind them to? Brand new channels that we can use to send messages on.
 
 ```javascript
-new pizzaShop, stdout(`rho:io:stdout`) in {
+new result, pizzaShop in {
 
   // Same contract as before
   contract pizzaShop(order) = {
-    stdout!("Order Received.")
+    result!("Order Received.")
   }
   |
   // Known customers can order because pizzaShop is bound here.
@@ -81,7 +81,7 @@ What happens when you try to order a pizza from outside of the `new` restriction
 - [x] Error about top-level free variables
 - [ ] The code runs, but no order is received
 
-We learned that all names quote processes. So what process does the `pizzaShop` name quote? Try printing the process to `stdout` to see
+We learned that all names quote processes. So what process does the `pizzaShop` name quote? Try printing the process to `result` to see
 - [ ] It quotes "pizzaShop"
 - [ ] It doesn't quote anything
 - [x] "Some Unforgeable hex code"
@@ -109,7 +109,7 @@ new alice, bob, pizzaShop in {
 
   // Now we take an order and an ack channel
   contract pizzaShop(order, ack) = {
-    // Instead of acknowledging via stdout, we use ack
+    // Instead of acknowledging via result, we use ack
     ack!("Order Received.")
   }
   |
@@ -124,7 +124,7 @@ new alice, bob, pizzaShop in {
 Why don't the acknowledgements in the previous example show up on the screen?
 - [ ] There is a bug in the code
 - [ ] The orders were not received correctly
-- [x] The confirmation was not sent to `stdout`
+- [x] The confirmation was not sent to `result`
 
 
 
@@ -168,7 +168,7 @@ new myAckChannel,
   stdoutAck!("Print some words.", *myAckChannel)
   |
   for (acknowledgement <- myAckChannel) {
-    stdout!("Received an acknowledgement.")
+    result!("Received an acknowledgement.")
   }
 }
 ```
@@ -177,7 +177,7 @@ By the way, did you ever notice the handful of stuff that always starts in a fre
 
 
 ### Exercise
-`stdout!("1") | stdout!("2") | stdout!("3")`
+`result!("1") | result!("2") | result!("3")`
 Notice that this program does not print the numbers in any particular order. The calls happen concurrently. Imagine we really need these lines to print in order. Modify the code to use ack channels and ensure that the numbers get printed in order.
 
 ### Exercise
@@ -188,7 +188,7 @@ new myChan in {
   myChan!("Hi There")
 }
 |
-for (msg <- myChan) {stdout!(*msg)}
+for (msg <- myChan) {result!(*msg)}
 ```
 
 If your prediction for the previous exercise was wrong, modify the program so it actually does what you predicted it would.

--- a/content/tutorials/unforgable-names.md
+++ b/content/tutorials/unforgable-names.md
@@ -156,9 +156,9 @@ Bob also wants to order a pizza and give a unforgeable ack channel. Where should
 - [ ] On the same line Alice did
 - [ ] On the very first line of the program
 
-## `stdoutAck` and `stderrAck`
+## `stdout`, `stderr`, `stdoutAck` and `stderrAck`
 
-Now that you understand ack channels, you should know about two other ways to print to the screen. They are channels called `stdoutAck` and `stderrAck`. They work just like their cousins from lesson 1, but they take an ack channel.
+Now that you understand ack channels, you should know about ways to print to the rnode log file. They are channels called `stdout`, `stderr`, `stdoutAck` and `stderrAck`. They work just like their cousins `result` from lesson 1, but they print to the rnode log.
 
 ```javascript
 new myAckChannel,


### PR DESCRIPTION
the rholang by example examples are changed to use explore with the result as first new name so the result is obtained without requiring access to the log.